### PR TITLE
convert to streaming generator and report usage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 steamship==2.17.32
 openai==1.1.1
+requests

--- a/src/api.py
+++ b/src/api.py
@@ -217,7 +217,6 @@ class DallEPlugin(Generator):
         return InvocableResponse(data=RawBlockAndTagPluginOutput(blocks=generated_blocks))
 
     def _inputs_from_config_and_runtime_params(self, options: Optional[dict]) -> dict:
-
         if options is not None and "model" in options:
             raise SteamshipError(
                 "Model may not be overridden in runtime options. "

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "plugin",
 	"handle": "dall-e",
-	"version": "0.0.1-rc.17",
+	"version": "0.0.1-rc.18",
 	"description": "",
 	"author": "dave",
 	"entrypoint": "Unused",
@@ -26,7 +26,7 @@
 		},
 		"model": {
 			"type": "string",
-			"description": "Model to use for image generation. Must be one of: ['dall-e-2', 'dall-e-3']",
+			"description": "Model to use for image generation. Must be one of: ['dall-e-2', 'dall-e-3']. Not available for runtime override.",
 			"default": "dall-e-2"
 		},
 		"n": {
@@ -36,7 +36,7 @@
 		},
 		"size": {
 			"type": "string",
-			"description": "Default size of the output images. Must be one of:['1024x1024', '512x512', '256x256', '1792x1024', '1024x1792'].",
+			"description": "Size of the output images. Must be one of:['1024x1024', '512x512', '256x256', '1792x1024', '1024x1792']. Not available for runtime override.",
 			"default": "1024x1024"
 		},
 		"max_retries": {

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "plugin",
 	"handle": "dall-e",
-	"version": "0.0.1-rc.16",
+	"version": "0.0.1-rc.17",
 	"description": "",
 	"author": "dave",
 	"entrypoint": "Unused",
@@ -10,7 +10,7 @@
 		"isTrainable": false,
 		"transport": "jsonOverHttp",
 		"type": "generator",
-		"streaming": false
+		"streaming": true
 	},
 	"build_config": {
 		"ignore": [

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -24,3 +24,24 @@ def test_generator():
             # check that Steamship thinks it is a PNG and that the bytes seem like a PNG
             assert block.mime_type == MimeTypes.PNG
             assert filetype.guess_mime(block.raw()) == MimeTypes.PNG
+
+
+def test_generator_streaming():
+    with Steamship.temporary_workspace() as steamship:
+        dalle = steamship.use_plugin(GENERATOR_HANDLE)
+
+        task = dalle.generate(
+            text="A cat on a bicycle",
+            append_output_to_file=True,
+            options={"n": 2, "size": "256x256"},
+            streaming=True,
+        )
+        task.wait()
+
+        blocks = task.output.blocks
+        assert blocks is not None
+        assert len(blocks) == 2
+        for block in blocks:
+            # check that Steamship thinks it is a PNG and that the bytes seem like a PNG
+            assert block.mime_type == MimeTypes.PNG
+            assert filetype.guess_mime(block.raw()) == MimeTypes.PNG

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -1,41 +1,8 @@
 import pytest
 from pydantic import ValidationError
-from steamship import Block, SteamshipError, TaskState
-from steamship.plugin.inputs.raw_block_and_tag_plugin_input import RawBlockAndTagPluginInput
-from steamship.plugin.request import PluginRequest
+from steamship import SteamshipError
 
 from api import DallEPlugin, ImageSizeEnum
-
-
-def test_generator():
-    dalle = DallEPlugin()
-    request = PluginRequest(
-        data=RawBlockAndTagPluginInput(blocks=[Block(text="a cat riding a bicycle")])
-    )
-    response = dalle.run(request)
-
-    assert response.status.state is TaskState.succeeded
-    assert response.data is not None
-
-    assert len(response.data.blocks) == 1
-    assert response.data.blocks[0].url is not None
-
-
-def test_generator_overrides():
-    dalle = DallEPlugin()
-    request = PluginRequest(
-        data=RawBlockAndTagPluginInput(
-            blocks=[Block(text="a cat riding a bicycle")], options={"n": 2, "size": "512x512"}
-        )
-    )
-    response = dalle.run(request)
-
-    assert response.status.state is TaskState.succeeded
-    assert response.data is not None
-
-    assert len(response.data.blocks) == 2
-    for block in response.data.blocks:
-        assert block.url is not None
 
 
 def test_generator_validation():

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -1,8 +1,72 @@
 import pytest
 from pydantic import ValidationError
-from steamship import SteamshipError
+from steamship import Block, File, MimeTypes, Steamship, SteamshipError
+from steamship.plugin.inputs.raw_block_and_tag_plugin_input import RawBlockAndTagPluginInput
+from steamship.plugin.inputs.raw_block_and_tag_plugin_input_with_preallocated_blocks import (
+    RawBlockAndTagPluginInputWithPreallocatedBlocks,
+)
+from steamship.plugin.outputs.plugin_output import UsageReport
+from steamship.plugin.request import PluginRequest
 
 from api import DallEPlugin, ImageSizeEnum
+
+
+def run_test_streaming(
+    client: Steamship, plugin: DallEPlugin, blocks: [Block], options: dict
+) -> ([UsageReport], [Block]):
+    blocks_to_allocate = plugin.determine_output_block_types(
+        PluginRequest(data=RawBlockAndTagPluginInput(blocks=blocks, options=options))
+    )
+    file = File.create(client, blocks=[])
+    output_blocks = []
+    for block_type_to_allocate in blocks_to_allocate.data.block_types_to_create:
+        assert block_type_to_allocate == MimeTypes.PNG.value
+        output_blocks.append(
+            Block.create(
+                client,
+                file_id=file.id,
+                mime_type=MimeTypes.PNG.value,
+                streaming=True,
+            )
+        )
+
+    response = plugin.run(
+        PluginRequest(
+            data=RawBlockAndTagPluginInputWithPreallocatedBlocks(
+                blocks=blocks, options=options, output_blocks=output_blocks
+            )
+        )
+    )
+    result_blocks = [Block.get(client, _id=block.id) for block in output_blocks]
+    return response.data.usage, result_blocks
+
+
+def test_generator():
+    with Steamship.temporary_workspace() as client:
+        dalle = DallEPlugin()
+        usage, new_blocks = run_test_streaming(
+            client, dalle, [Block(text="a cat riding a bicycle")], options={}
+        )
+
+        assert new_blocks is not None
+        assert len(new_blocks) == 1
+
+        assert usage is not None
+        assert len(usage) == 1
+
+
+def test_generator_overrides():
+    with Steamship.temporary_workspace() as client:
+        dalle = DallEPlugin(config={"size": "512x512"})
+        usage, new_blocks = run_test_streaming(
+            client, dalle, [Block(text="a cat riding a bicycle")], options={"n": 2}
+        )
+
+        assert new_blocks is not None
+        assert len(new_blocks) == 2
+
+        assert usage is not None
+        assert len(usage) == 2
 
 
 def test_generator_validation():
@@ -15,12 +79,6 @@ def test_generator_validation():
     with pytest.raises(SteamshipError) as e:
         dalle = DallEPlugin()
         dalle.generate_with_retry(user="foo", prompt="bar", options={"n": 12})
-
-    assert "Invalid runtime parameterization of plugin" in str(e)
-
-    with pytest.raises(SteamshipError) as e:
-        dalle = DallEPlugin()
-        dalle.generate_with_retry(user="foo", prompt="bar", options={"size": "fadsfadsf"})
 
     assert "Invalid runtime parameterization of plugin" in str(e)
 
@@ -54,3 +112,6 @@ def test_no_override_of_model_at_runtime():
 
     with pytest.raises(SteamshipError):
         plugin._inputs_from_config_and_runtime_params(options={"model": "dall-e-3"})
+
+    with pytest.raises(SteamshipError):
+        plugin._inputs_from_config_and_runtime_params(options={"size": "should fail"})


### PR DESCRIPTION
Converts to a streaming generator, reporting usage of 1 UNITS per image requested.