### PR TITLE
prevent override of quality at runtime

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -260,6 +260,12 @@ class DallEPlugin(StreamingGenerator):
                 "Please configure 'size' when creating a plugin instance."
             )
 
+        if options is not None and "quality" in options:
+            raise SteamshipError(
+                "Quality may not be overridden in runtime options. "
+                "Please configure 'quality' when creating a plugin instance."
+            )
+
         temp_config = DallEPlugin.DallEPluginConfig(**self.config.dict())
         temp_config.extend_with_dict(options, overwrite=True)
         validated_config = DallEPlugin.DallEPluginConfig(**temp_config.dict())

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -115,3 +115,6 @@ def test_no_override_of_model_at_runtime():
 
     with pytest.raises(SteamshipError):
         plugin._inputs_from_config_and_runtime_params(options={"size": "should fail"})
+
+    with pytest.raises(SteamshipError):
+        plugin._inputs_from_config_and_runtime_params(options={"quality": "should fail"})


### PR DESCRIPTION
Turns out `quality` impacts pricing.